### PR TITLE
More reliable process tracking (in Kubernetes) and UTF8 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/ap
         && apt-get -y update \
         && apt-get --no-upgrade --no-install-suggests --no-install-recommends -y install tini openjdk-11-jre-headless  libjpeg-progs dcraw exiftool psmisc
 
+
 ADD https://www.picapport.de/download/${VERSION}/picapport-headless.jar /opt/picapport/picapport-headless.jar
 
 # Plugin do not carry versions in their files / download locations. Current versions according to https://www.picapport.de/de/plugins.php
@@ -47,7 +48,7 @@ RUN addgroup --gid $PICAPPORT_UID $PICAPPORT_USER \
 
 VOLUME [ "/opt/picapport/data", "/opt/picapport/photos" ]
 USER $PICAPPORT_USER
-ENTRYPOINT ["tini", "--"]
+ENTRYPOINT ["tini", "-g", "--"]
 CMD [ "/bin/bash", "-c" , "/opt/picapport/picapport.sh $PICAPPORT_PORT $PICAPPORT_LANG $PICAPPORT_LOGLEVEL $PICAPPORT_JAVAPARS" ]
 
 LABEL version=$VERSION \

--- a/picapport.sh
+++ b/picapport.sh
@@ -8,15 +8,15 @@ PICAPPORT_JAVAPARS="$4"
 PAUSERHOME="/opt/picapport"
 PAPHOTOPATH="${PAUSERHOME}/photos"
 PADIR="data"
-CONFIG="$PAUSERHOME/$PADIR/picapport.properties"
+DEFAULT_CONFIG="$PAUSERHOME/$PADIR/picapport.properties"
 ENVFILE="$PADIR/ENV"
 PLUGINSDIR="$PAUSERHOME/$PADIR/plugins"
 ADDONSDIR="$PAUSERHOME/$PADIR/groovy"
 
 function clean_up {
   echo "=== Shutting down..."
-  killall java
-  wait %1
+  killall -w java
+  [ -e "$PAUSERHOME/$PADIR/PicApport.lck" ] && rm "$PAUSERHOME/$PADIR/PicApport.lck"
   echo "=== Shutdown complete. ==="
   exit
 }
@@ -51,14 +51,13 @@ fi
 [ -z "$PICAPPORT_LANG" ] && PICAPPORT_LANG="de"
 [ -z "$PICAPPORT_LOGLEVEL" ] && PICAPPORT_LOGLEVEL="WARNING"
 [ -z "$PICAPPORT_JAVAPARS" ] && PICAPPORT_JAVAPARS=" "
+[ -z "$CONFIG"] && CONFIG=${DEFAULT_CONFIG}
 
 # install a minimal config if there is none present
 [ ! -f "$CONFIG" ] && printf "%s\n%s\n%s\n" "server.port=$PICAPPORT_PORT" "robot.root.0.path=$PAPHOTOPATH" "foto.jpg.usecache=2" > "$CONFIG"
 
 echo "=== Starting picapport process (with $(id))..."
 java -Duser.language="$PICAPPORT_LANG" -DTRACE="$PICAPPORT_LOGLEVEL" -Duser.home="$PAUSERHOME" -Dpicapport.directory="$PADIR" $PICAPPORT_JAVAPARS \
-  -jar "$PAUSERHOME/picapport-headless.jar" -configfile="$CONFIG" -pgui.enabled=false &
+  -jar "$PAUSERHOME/picapport-headless.jar" -configfile="$CONFIG" -pgui.enabled=false
 
-while true; do sleep 1; done    # wait for shutdown signals
-
-
+clean_up


### PR DESCRIPTION
This small PR fixes issues where java crashes didn't stop the container, which blocks the restart especially in kubernetes environments.

Further it allows to move the config file to a different path. (Also useful if the properties should be stored in a config map in Kubernetes)

Setting LC_ALL=C.UTF-8 make the container work with international characters e.g. umlauts, without the need to maintain another version of the Docker file or a separate branch. 